### PR TITLE
Hide password from logs

### DIFF
--- a/cypress/support/commands/login/login.js
+++ b/cypress/support/commands/login/login.js
@@ -1,7 +1,7 @@
-Cypress.Commands.add("loginUI", (email, password, tenantID) => { 
+Cypress.Commands.add("loginUI", (email, password, tenantID) => {
   cy.visit(`${Cypress.config().baseUrl}/en/login`);
   cy.get("[data-cy='tenant-input']").type(tenantID);
   cy.get("[data-cy='login-input']").type(email);
-  cy.get("[data-cy='password-input']").type(password);
+  cy.get("[data-cy='password-input']").type(password, { log: false });
   cy.get("[data-cy='login-button']").click();
 });


### PR DESCRIPTION
# Problem
The user's password is shown in the logs

# Solution
* **Login functionality**
    * Add `{ log: false }` as a second parameter of the `type` command.
    
# Tasks
- [x] Add second parameter to the `type` command
- [x] Manually run the tests and check they pass