### PR TITLE
Mock login response

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -4,7 +4,6 @@ module.exports = defineConfig({
   timeDelayEnabled: false,
   timeDelay: 1000,
   chromeWebSecurity: false,
-  videoUploadOnPasses: false,
   videoCompression: 0,
   defaultCommandTimeout: 20000,
   e2e: {

--- a/cypress/e2e/api-schema-validation/validate-api-OpenAPI-schema.spec.js
+++ b/cypress/e2e/api-schema-validation/validate-api-OpenAPI-schema.spec.js
@@ -12,7 +12,7 @@ const path = "/v1/vehicles/4Y1SL65848Z411439/status/odometer";
 const endpoint = "/vehicles/{vin}/status/odometer";
 const baseUrl = `${server}${path}`;
 describe("API Schema Validation with OpenAPI - Custom Command", () => {
-  it("Checks the user data by using a plain JSON Schema", () => {
+  it("Checks the user data by using an OpenAPI JSON Schema", () => {
     cy.request("GET", baseUrl)
       .validateSchema(schema, {
         endpoint: endpoint,
@@ -35,7 +35,7 @@ describe("API Schema Validation with OpenAPI - Custom Command", () => {
 * with cy.request().
 */
 describe("API Schema Validation with OpenAPI - Function", () => {
-  it("Checks the user data by using a plain JSON Schema", () => {
+  it("Checks the user data by using an OpenAPI JSON Schema", () => {
     cy.request("GET", baseUrl).then((response) => {
       const data = response.body;
       const errors = validateSchema(data, schema, {

--- a/cypress/e2e/login/testbench-cloud/alternative-scenarios/failed-login.spec.js
+++ b/cypress/e2e/login/testbench-cloud/alternative-scenarios/failed-login.spec.js
@@ -1,0 +1,31 @@
+describe("Regular login via the UI", () => {
+  const login = {
+    emailAddress: Cypress.env("email"),
+    password: Cypress.env("password"),
+    userName: Cypress.env("userName"),
+    tenantID: Cypress.env("tenantID"),
+  };
+
+  it("Should display an error message even with valid credentials", () => {
+    // Mock the login API response as being unauthorized
+    cy.intercept("POST", "/api/tenants/login/session", {
+      statusCode: 403,
+      body: {
+        failureType: "LoginFailedIncorrectData",
+        message: "Incorrect workspace, login or password.",
+      },
+    }).as("validateUser");
+
+    // Enter valid credentials, the user should not be logged in
+    // as we have mocked the response of the intercepted API
+    cy.loginUI(login.emailAddress, login.password, login.tenantID);
+    cy.waitAndAssertStatusCode("validateUser", 403);
+
+    // Validate that the error message is displayed
+    cy.contains(
+      "Please enter a matching set of workspace, user login and password."
+    ).should("be.visible");
+    // Verify that the URL has not changed
+    cy.url().should("include", "/login");
+  });
+});

--- a/cypress/e2e/login/testbench-cloud/alternative-scenarios/mock-failed-login.spec.js
+++ b/cypress/e2e/login/testbench-cloud/alternative-scenarios/mock-failed-login.spec.js
@@ -1,4 +1,4 @@
-describe("Regular login via the UI", () => {
+describe("Attempt to log in via the UI while mocking the response", () => {
   const login = {
     emailAddress: Cypress.env("email"),
     password: Cypress.env("password"),

--- a/cypress/support/commands/login/login.js
+++ b/cypress/support/commands/login/login.js
@@ -1,8 +1,8 @@
 Cypress.Commands.add("loginUI", (email, password, tenantID) => {
   cy.visit(`${Cypress.config().baseUrl}/en/login`);
-  cy.get("[data-cy='tenant-input']").type(tenantID);
-  cy.get("[data-cy='login-input']").type(email, { log: false });
-  cy.get("[data-cy='password-input']").type(password, { log: false });
+  cy.get("[data-cy='tenant-input']").type(tenantID, { delay: 0 });
+  cy.get("[data-cy='login-input']").type(email, { log: false, delay: 0 });
+  cy.get("[data-cy='password-input']").type(password, { log: false, delay: 0 });
   cy.get("[data-cy='login-button']").click();
 });
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "cy:open": "cypress open",
+    "cy:run": "cypress run", 
+    "cy:regression": "cypress run --env TAG=regression"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
# Problem
We've added login tests  through the UI and via the API, but we haven't account for alternative cases where we may get a `403` server error.

# Solution
## Main changes
* Add a new login test, mocking the response
* Add a script to manually run the tests from the terminal

## Minor changes
* Remove the `videoUploadOnPasses` config option as it was removed in Cypress 13
* Optimize the `.type` command by adding the `{ delay:0 }` parameter so all the text is entered at once and not char by char.

# Tasks
- [x] Mock a new `login` test
- [x] Manually run the test and check it passes