### PR TITLE
Remove all the after hooks (anti-pattern)

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,6 @@
 {
-    "trailingComma": "all",
-    "tabWidth": 2,
-    "semi": false,
-    "singleQuote": true
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true
 }

--- a/cypress/e2e/login/orangehrm-cloud/login.spec.js
+++ b/cypress/e2e/login/orangehrm-cloud/login.spec.js
@@ -6,10 +6,21 @@ describe('Regular login via the UI', () => {
       'POST',
       'https://opensource-demo.orangehrmlive.com/web/index.php/auth/validate',
     ).as('validateUser')
+
+    // An uncaught exception is thrown on the app's Dashboard
+    cy.on('uncaught:exception', (err, runnable) => {
+      expect(err.message).to.include(
+        `Cannot read properties of undefined (reading 'response')`,
+      )
+      return false
+    })
     cy.log(`**--- Log in with regular user's credentials via the UI---**`)
 
-    // Let's cache the browser context linked to the user
-    // and reuse it for multiple tests
+    /*
+     * Let's set up a session to log in once, cache the browser context linked to the user
+     * and reuse it for multiple tests. Cypress will remember your cookies
+     * and local storage state from this session for reuse across tests.
+     */
     cy.session(login.userName, () => {
       cy.loginOrangeHrmUI(login.userName, login.password, login.orangeHrmUrl)
       cy.waitAndAssertStatusCode('validateUser', 302)
@@ -17,31 +28,27 @@ describe('Regular login via the UI', () => {
     })
   })
 
-  after(() => {
-    cy.log('**--- Log out the user (via UI) ---**')
-    cy.logoutOrangeHrmUI(login.orangeHrmUrl)
-  })
-
   it(
     'Checks a regular User can access the app (OrangeHR)',
     { tags: ['@loginUI', '@regression'] },
     () => {
-      // An uncaught exception is thrown on the Dashboard
-      cy.on('uncaught:exception', (err, runnable) => {
-        expect(err.message).to.include(
-          `Cannot read properties of undefined (reading 'response'`,
-        )
-        return false
-      })
-
       cy.visit(login.orangeHrmUrl)
       cy.url().should('include', '/dashboard')
-      cy.log(`**--- Verify user's name---**`)
 
-      // We cannot use the user's name as it changes everytime we log in
+      cy.log(`**--- Verify user's name---**`)
+      // We cannot use the user's name as it changes every time we log in
       // cy.get(".oxd-userdropdown-name").should('have.text', login.user)
-      // Let's then assert the title
+      // Let's then assert the title (unfortunately I have to use the class name)
       cy.get('.oxd-topbar-header-title').contains('Dashboard')
+    },
+  )
+  it(
+    'Checks a regular User can log out from the app',
+    { tags: ['@logoutUI', '@regression'] },
+    () => {
+      cy.visit(login.orangeHrmUrl)
+      cy.log('**--- Log out the user (via UI) ---**')
+      cy.logoutOrangeHrmUI(login.orangeHrmUrl)
     },
   )
 })

--- a/cypress/e2e/login/testbench-cloud/login.spec.js
+++ b/cypress/e2e/login/testbench-cloud/login.spec.js
@@ -10,8 +10,11 @@ describe('Regular login via the UI', () => {
     cy.intercept('POST', '/api/tenants/login/session').as('verifyUser')
     cy.log(`**--- Log in with regular user's credentials via the UI---**`)
 
-    // Let's cache the browser context linked to the user
-    // and reuse it for multiple tests
+    /*
+     * Let's set up a session to log in once, cache the browser context linked to the user
+     * and reuse it for multiple tests. Cypress will remember your cookies
+     * and local storage state from this session for reuse across tests.
+     */
     cy.session(login.emailAddress, () => {
       cy.loginUI(login.emailAddress, login.password, login.tenantID)
       cy.waitAndAssertStatusCode('verifyUser', 201)
@@ -19,10 +22,6 @@ describe('Regular login via the UI', () => {
     })
   })
 
-  after(() => {
-    cy.log('**--- Log out the user (via UI) ---**')
-    cy.logoutUI()
-  })
   it('Checks a regular User can access the app', { tags: '@loginUI' }, () => {
     cy.visit(`${Cypress.config().baseUrl}/en/products`)
     cy.url().should('include', '/products')
@@ -32,4 +31,13 @@ describe('Regular login via the UI', () => {
       login.userName,
     )
   })
+  it(
+    'Checks a regular User can log out from the app',
+    { tags: ['@logoutUI', '@regression'] },
+    () => {
+      cy.visit(`${Cypress.config().baseUrl}/en/products`)
+      cy.log('**--- Log out the user (via UI) ---**')
+      cy.logoutUI()
+    },
+  )
 })

--- a/cypress/e2e/login/testbench-cloud/loginviaAPI.spec.js
+++ b/cypress/e2e/login/testbench-cloud/loginviaAPI.spec.js
@@ -19,11 +19,6 @@ describe('Log in via the API', () => {
     })
   })
 
-  after(() => {
-    cy.log('**--- Log out the user (via API) ---**')
-    cy.logoutViaAPI(SESSION_TOKEN)
-  })
-
   it(
     'Checks a regular User can access the app',
     { tags: '@loginAPI' },
@@ -35,6 +30,15 @@ describe('Log in via the API', () => {
         'have.text',
         login.userName,
       )
+    },
+  )
+  it(
+    'Checks a regular User can log out from the app',
+    { tags: ['@logoutUI', '@regression'] },
+    () => {
+      cy.visit(`${Cypress.config().baseUrl}/en/products`)
+      cy.log('**--- Log out the user (via API) ---**')
+      cy.logoutViaAPI(SESSION_TOKEN)
     },
   )
 })


### PR DESCRIPTION
# Problem
Using `after()` hooks in my login tests to clean up data is an anti-pattern or bad practice.

# Solution
Remove all the `after()` from the tests and move the logout functionality to a separate test itself.

# Tasks
- [x] Manually run the impacted tests and check they all pass